### PR TITLE
Docs: more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ Give it a minute to initialize a channel, then you're done! A configuration
 file will be created in `~/.moneyd.test.json`.
 
 So long as that command is running, you'll have access to ILP via port 7768.
-The [Sending Payments](#sending-payments) section describes servers on the live
-network right now, but will soon be updated to include examples that you can
-try from the test network.
+To try it out, follow the [Sending Payments](#sending-payments) section, and
+use the alternate endpoints listed for the testnet.
 
 ### Live Network
 
@@ -133,6 +132,7 @@ const SPSP = require('ilp-protocol-spsp')
 async function run () {
   console.log('paying $sharafian.com...')
 
+  # use '$spsp.ilp-test.com' if you're on the testnet
   await SPSP.pay(plugin, {
     receiver: '$sharafian.com',
     sourceAmount: '10'
@@ -265,8 +265,11 @@ to moneyd and send money to the unhash host.
 ```sh
 npm install -g ilp-curl
 echo "This is my example file" > example.txt
+
+# use "https://unhash.ilp-test.com" if you're on the testnet"
 ilp-curl -X POST https://alpha.unhash.io --data @example.txt
 # --> {"digest":"ff5574cef56e644f3fc4d0311b15a3e95f115080bcc029889f9e32121fd60407"}
+
 curl https://alpha.unhash.io/ff5574cef56e644f3fc4d0311b15a3e95f115080bcc029889f9e32121fd60407
 # --> "This is my example file"
 ```
@@ -277,7 +280,10 @@ example will send a micropayment to `$sharafian.com`.
 
 ```sh
 npm install -g ilp-spsp
+
+# use "$spsp.ilp-test.com" if you're on the testnet
 ilp-spsp send --receiver \$sharafian.com --amount 100
+
 # --> paying 100 to "$sharafian.com"...
 # --> sent!
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
   - [Live Network](#live-network)
   - [Local Test Network](#local-test-network)
 - [Description](#description)
+- [Writing ILP Applications](#writing-ilp-applications)
+  - [Making an SPSP Payment](#making-an-spsp-payment)
+  - [How Does "ilp-plugin" Work?](#how-does-ilp-plugin-work)
 - [Advanced Usage](#usage)
   - [Command-Line Options](#command-line-options)
   - [Remote Deploy](#remote-deploy)
@@ -98,6 +101,61 @@ other tools will work right out of the box.
 
 Because it's in early stages, don't use it
 with a ripple account that has too much money.
+
+## Writing ILP Applications
+
+One of the biggest reasons to run moneyd is that it lets you develop your own
+applications that run on top of Interledger. Connecting to Moneyd is as easy as
+installing [`ilp-plugin`](https://www.npmjs.com/package/ilp-plugin) and adding
+a single line of code to your project:
+
+```
+const plugin = require('ilp-plugin')()
+```
+
+This Interledger
+[Plugin](https://github.com/interledger/rfcs/blob/master/0024-ledger-plugin-interface-2/0024-ledger-plugin-interface-2.md)
+is a connection to your Moneyd instance. You can then pass it into other
+modules to send payments through your Moneyd.
+
+### Making an SPSP Payment
+
+The snippet of code below shows how to use `ilp-plugin` and
+[`ilp-protocol-spsp`] to pay the identifier `$sharafian.com`. This identifier
+is only reachable on the livenet; If you want to send to somewhere on the
+testnet, use [SPSP server](https://github.com/sharafian/ilp-spsp-server) to
+create your own receiver.
+
+```
+const plugin = require('ilp-plugin')()
+const SPSP = require('ilp-protocol-spsp')
+
+async function run () {
+  console.log('paying $sharafian.com...')
+
+  await SPSP.pay(plugin, {
+    receiver: '$sharafian.com',
+    sourceAmount: '10'
+  })
+
+  console.log('paid!')
+}
+
+run().catch(e => console.error(e))
+```
+
+### How Does "ilp-plugin" Work?
+
+`ilp-plugin` has very simple default behavior. If you run
+`require('ilp-plugin')()`, it creates an instance of [ILP Plugin
+BTP](https://github.com/interledgerjs/ilp-plugin-btp) that connects to port
+7768 on your local machine.
+
+You can also customize the behavior of `ilp-plugin` using [environment
+variables](https://en.wikipedia.org/wiki/Environment_variable#Unix).
+
+- `ILP_CREDENTIALS` - A JSON object that contains the parameters to be passed into your plugin's constructor. Default: `'{"server":"btp+ws://:<RANDOM_SECRET>@localhost:7768"}'`.
+- `ILP_PLUGIN` - An NPM module name for the plugin you want to use. Default: `'ilp-plugin-btp'`.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ modules to send payments through your Moneyd.
 ### Making an SPSP Payment
 
 The snippet of code below shows how to use `ilp-plugin` and
-[`ilp-protocol-spsp`] to pay the identifier `$sharafian.com`. This identifier
+[`ilp-protocol-spsp`](https://github.com/sharafian/ilp-protocol-spsp) to pay the identifier `$sharafian.com`. This identifier
 is only reachable on the livenet; If you want to send to somewhere on the
 testnet, use [SPSP server](https://github.com/sharafian/ilp-spsp-server) to
 create your own receiver.
@@ -132,7 +132,7 @@ const SPSP = require('ilp-protocol-spsp')
 async function run () {
   console.log('paying $sharafian.com...')
 
-  # use '$spsp.ilp-test.com' if you're on the testnet
+  // use '$spsp.ilp-test.com' if you're on the testnet
   await SPSP.pay(plugin, {
     receiver: '$sharafian.com',
     sourceAmount: '10'


### PR DESCRIPTION
Closes https://github.com/interledgerjs/moneyd-xrp/issues/18 .

Also adds alternate endpoints for the testnet hosted on https://ilp-test.com . Not yet sure what else we should do with that site; I'm hosting some developer tutorials there for now but we may want to just redirect it somewhere else.