### PR TITLE
Fix: env and admin api

### DIFF
--- a/bin/moneyd.js
+++ b/bin/moneyd.js
@@ -41,6 +41,10 @@ require('yargs')
     default: false,
     description: 'Whether to use the testnet config file'
   })
+  .option('admin-api-port', {
+    type: 'number',
+    description: 'Port on which to expose admin API (not exposed if unspecified)'
+  })
   .command('local', 'launch moneyd with no uplink into the network, for local testing', {}, argv => {
     console.log('launching local moneyd...')
     const allowedOrigins = []
@@ -199,6 +203,8 @@ function getConfig (argv) {
   const configData = fs.readFileSync(argv.config).toString()
   return new Config(Object.assign({
     rippled: argv.rippled || 'wss://s1.ripple.com',
+    environment: (argv.testnet ? 'test' : 'production'),
+    adminApiPort: argv['admin-api-port'],
     name: ''
   }, JSON.parse(configData)))
 }

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,8 @@ class Config {
     this.xrpSecret = opts.secret
     this.xrpAddress = opts.address || deriveAddress(deriveKeypair(this.xrpSecret).publicKey)
     this.xrpServer = opts.rippled
+    this.environment = opts.environment
+    this.adminApiPort = opts.adminApiPort
     this.api = null
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ exports.startFull = (config, allowedOrigins) => Connector.createApp({
   backend: 'one-to-one',
   store: 'ilp-store-memory',
   initialConnectTimeout: 60000,
+  env: config.environment,
+  adminApi: !!config.adminApiPort,
+  adminApiPort: config.adminApiPort,
   accounts: {
     parent: {
       relation: 'parent',
@@ -48,11 +51,7 @@ exports.startFull = (config, allowedOrigins) => Connector.createApp({
         allowedOrigins
       }
     }
-  },
-  routes: [{
-    targetPrefix: 'g.',
-    peerId: 'parent'
-  }]
+  }
 }).listen()
 
 exports.startLocal = (allowedOrigins) => Connector.createApp({


### PR DESCRIPTION
- Don't manually add `g.` route
- Add `admin-api-port` argument to expose admin api for debugging
- Set `CONNECTOR_ENV` variable (was causing issues on livenet)