### PR TITLE
Fix: allow admin API in local mode

### DIFF
--- a/bin/moneyd.js
+++ b/bin/moneyd.js
@@ -51,7 +51,10 @@ require('yargs')
     const allowedOrigins = []
       .concat(argv['allow-origin'] || [])
       .concat(argv['unsafe-allow-extensions'] ? 'chrome-extension://.*' : [])
-    moneyd.startLocal(allowedOrigins).catch(onError)
+
+    moneyd.startLocal({
+      adminApiPort: argv.adminApiPort
+    }, allowedOrigins).catch(onError)
   })
   .command('start', 'launch moneyd', {
     quiet: {

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ exports.startLocal = (config, allowedOrigins) => Connector.createApp({
   adminApi: !!config.adminApiPort,
   adminApiPort: config.adminApiPort,
   initialConnectTimeout: 60000,
-  ilpAddress: 'private.moneyd.',
+  ilpAddress: 'private.moneyd',
   accounts: {
     local: {
       relation: 'child',

--- a/src/index.js
+++ b/src/index.js
@@ -54,10 +54,12 @@ exports.startFull = (config, allowedOrigins) => Connector.createApp({
   }
 }).listen()
 
-exports.startLocal = (allowedOrigins) => Connector.createApp({
+exports.startLocal = (config, allowedOrigins) => Connector.createApp({
   spread: 0,
   backend: 'one-to-one',
   store: 'ilp-store-memory',
+  adminApi: !!config.adminApiPort,
+  adminApiPort: config.adminApiPort,
   initialConnectTimeout: 60000,
   ilpAddress: 'private.moneyd.',
   accounts: {

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ exports.startLocal = (allowedOrigins) => Connector.createApp({
   backend: 'one-to-one',
   store: 'ilp-store-memory',
   initialConnectTimeout: 60000,
-  ilpAddress: 'test.moneyd.',
+  ilpAddress: 'private.moneyd.',
   accounts: {
     local: {
       relation: 'child',


### PR DESCRIPTION
- Adds `adminApiPort` as config option for local mode
- Changes prefix from `test.` to `private.` in local mode
- Remove extra dot in ILP address