### PR TITLE
Fix: check if config file exists before doing anything

### DIFF
--- a/bin/moneyd.js
+++ b/bin/moneyd.js
@@ -118,6 +118,11 @@ require('yargs')
       process.exit(1)
     }
 
+    if (fs.existsSync(argv.config)) {
+      console.error('config file already exists. file=' + argv.config)
+      process.exit(1)
+    }
+
     if (!argv.testnet && !argv.secret) {
       console.error('XRP secret must be specified (--secret)')
       process.exit(1)


### PR DESCRIPTION
currently when you configure for the testnet, it waits for the account to get funded before checking if the file exists. I kept the other check in to make sure the file wasn't created by another process while we wait for account funding.